### PR TITLE
137 fix ip address parser for nmap xml reporter

### DIFF
--- a/reptor/plugins/tools/Nmap/Nmap.py
+++ b/reptor/plugins/tools/Nmap/Nmap.py
@@ -89,7 +89,14 @@ class Nmap(ToolBase):
         if not isinstance(hosts, list):
             hosts = [hosts]
         for host in hosts:
-            ip = host.get("address", {}).get("@addr")
+            netif_addrs = host.get("address", [])
+            # predefine value if error occurred
+            ip = "ERROR"
+            for if_addr in netif_addrs:
+                # skip mac address, only ipv4/ipv6 address should be included
+                if if_addr["@addrtype"].startswith("ip"):
+                    # get ip address from scan result
+                    ip = if_addr.get("@addr")
             ports = host.get("ports", {}).get("port", [])
             if not isinstance(ports, list):
                 ports = [ports]


### PR DESCRIPTION
Nmap.py: fix address parser for report with both MAC address and IP address

fix issue #137

For example:
```
<address addr="172.16.5.127" addrtype="ipv4"/>
<address addr="00:50:88:99:aa:bb" addrtype="mac" vendor="VMware"/>
```