### PR TITLE
Minor typo fixes in Toolbase.py and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for investing your time.
 # Licensing and dependencies
 By opening a pull request, you warrant that you own the rights to the code.
 This project is licensed under the MIT license and all merged pull requests will be either.
-Add yourself to the [credits](#credits) if you whish.
+Add yourself to the [credits](#credits) if you wish.
 
 # Dependencies
 You can use external dependencies if they have permissive licenses (like MIT, BSD, etc.) or licensed under LGPL. You can always use software under licenses on [Blue Oak Council’s permissive license list](https://blueoakcouncil.org/list) with a rating of “Bronze” or better.

--- a/reptor/templates/Toolbase/Toolbase.py
+++ b/reptor/templates/Toolbase/Toolbase.py
@@ -43,19 +43,19 @@ class MYMODULENAME(ToolBase):
         )
 
     def parse_xml(self, xml_root):
-        """This is called automatically if the user provices --format xml
+        """This is called automatically if the user provides --format xml
         For more infos look at the parent parse() method in ToolBase
         """
         super().parse_xml()
 
     def parse_json(self):
-        """This is called automatically if the user provices --format json
+        """This is called automatically if the user provides --format json
         For more infos look at the parent parse() method in ToolBase
         """
         super().parse_json()
 
     def parse_csv(self):
-        """This is called automatically if the user provices --format csv
+        """This is called automatically if the user provides --format csv
         For more infos look at the parent parse() method in ToolBase
         """
         ...


### PR DESCRIPTION
This PR fixes a couple of typos in the `Toolbase.py` and `CONTRIBUTING.md` files that I found while developing my own plugin for SysReptor. 

Happy to discuss any proposed changes :)