### PR TITLE
feat(plugins): add --json flag for scriptable plugin list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Upcoming
+* Add `reptor plugins --json` for scriptable plugin list output
+
 # 0.34
 * Allow pushing Zap findings to SysReptor reports (https://github.com/Syslifters/reptor/pull/242#issue-4082198330)
 * Add project data management tools to MCP server (https://github.com/Syslifters/reptor/pull/240#issue-3956788481)

--- a/reptor/plugins/core/Plugins/Plugins.py
+++ b/reptor/plugins/core/Plugins/Plugins.py
@@ -87,10 +87,19 @@ class Plugins(Base):
         )
 
     def _plugin_to_dict(self, plugin):
+        tags = getattr(plugin, "tags", None)
+        if not tags:
+            tags = []
+        try:
+            tags = list(tags)
+        except TypeError:
+            tags = []
+        tags = sorted([str(t) for t in tags])
+
         result = {
             "name": plugin.name,
             "summary": plugin.summary,
-            "tags": list(plugin.tags),
+            "tags": tags,
             "category": plugin.category,
             "author": plugin.author,
             "version": plugin.version,

--- a/reptor/plugins/core/Plugins/Plugins.py
+++ b/reptor/plugins/core/Plugins/Plugins.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import shutil
 
@@ -21,6 +22,7 @@ class Plugins(Base):
     * --search    Allows you to search for a specific plugin by name and tag
     * --copy PLUGINNAME      Copies a plugin to your local folder for development
     * --new PLUGINNAME  Creates a new plugin based off a template and your input
+    * --json      Output the plugin list as JSON (scriptable)
     * --verbose   Provides more information about a plugin
 
     # Developer Notes
@@ -40,6 +42,7 @@ class Plugins(Base):
         self.copy_plugin_name = kwargs.get("copy_plugin_name")
         self.copy_full = kwargs.get("full")
         self.verbose = kwargs.get("verbose")
+        self.json = kwargs.get("json", False)
 
     @classmethod
     def add_arguments(cls, parser, plugin_filepath=None):
@@ -76,8 +79,38 @@ class Plugins(Base):
             action="store_true",
             help="At copy include plugin source code; default: templates only",
         )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Output plugin list as JSON (scriptable)",
+            dest="json",
+        )
+
+    def _plugin_to_dict(self, plugin):
+        result = {
+            "name": plugin.name,
+            "summary": plugin.summary,
+            "tags": list(plugin.tags),
+            "category": plugin.category,
+            "author": plugin.author,
+            "version": plugin.version,
+            "license": plugin.license,
+            "website": plugin.website,
+        }
+        overwritten = plugin.get_overwritten_plugin()
+        if overwritten:
+            result["overwrites"] = {
+                "name": overwritten.name,
+                "category": overwritten.category,
+            }
+        return result
 
     def _list(self, plugins):
+        if self.json:
+            payload = [self._plugin_to_dict(tool) for tool in plugins]
+            self.print(json.dumps(payload, indent=2))
+            return
+
         if self.verbose:
             table = make_table(
                 [
@@ -135,7 +168,8 @@ class Plugins(Base):
         for _, group_plugins in subcommands.SUBCOMMANDS_GROUPS.items():
             plugins.extend(group_plugins[1])
         if self.search:
-            self.console.print(f"\nSearching for: [red]{self.search}[/red]\n")
+            if not self.json:
+                self.console.print(f"\nSearching for: [red]{self.search}[/red]\n")
             results = list()
             for plugin in plugins:
                 if self.search in plugin.tags:

--- a/reptor/plugins/core/Plugins/tests/test_plugins_json.py
+++ b/reptor/plugins/core/Plugins/tests/test_plugins_json.py
@@ -7,7 +7,6 @@ SysReptor server (no integration marker).
 
 import io
 import json
-import sys
 
 from reptor.lib.plugins.PluginMeta import PluginMeta
 from reptor.plugins.core.Plugins.Plugins import Plugins
@@ -73,6 +72,18 @@ class TestPluginsJsonFlag:
         override.set_overwrites_plugin(base)
         result = Plugins(json=True)._plugin_to_dict(override)
         assert result["overwrites"] == {"name": "Base", "category": "tools"}
+
+    def test_plugin_to_dict_sorts_tags_when_set(self):
+        plugin = _make_plugin("Tagged", tags=["b", "a"])
+        plugin.tags = {"b", "a"}
+        result = Plugins(json=True)._plugin_to_dict(plugin)
+        assert result["tags"] == ["a", "b"]
+
+    def test_plugin_to_dict_handles_none_tags(self):
+        plugin = _make_plugin("NoTags", tags=[])
+        plugin.tags = None
+        result = Plugins(json=True)._plugin_to_dict(plugin)
+        assert result["tags"] == []
 
     def test_list_outputs_valid_json_array(self):
         plugins = [

--- a/reptor/plugins/core/Plugins/tests/test_plugins_json.py
+++ b/reptor/plugins/core/Plugins/tests/test_plugins_json.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for the --json output flag on `reptor plugins`.
+
+Mirrors the test style of the existing PluginMeta tests; runs without a live
+SysReptor server (no integration marker).
+"""
+
+import io
+import json
+import sys
+
+from reptor.lib.plugins.PluginMeta import PluginMeta
+from reptor.plugins.core.Plugins.Plugins import Plugins
+
+
+def _make_plugin(name, *, category="core", summary="", tags=None,
+                 author="", version="", license="", website=""):
+    meta = {
+        "summary": summary,
+        "tags": list(tags or []),
+        "author": author,
+        "version": version,
+        "license": license,
+        "website": website,
+    }
+    plugin = PluginMeta(meta)
+    plugin.name = name
+    plugin.category = category
+    return plugin
+
+
+class TestPluginsJsonFlag:
+    def _run_list(self, plugins, json_flag):
+        """Construct a Plugins instance and capture stdout from _list()."""
+        instance = Plugins(json=json_flag)
+        # Replace Base.print with a captured stdout writer
+        buf = io.StringIO()
+        instance.print = lambda *a, **kw: print(*a, file=buf, **kw)
+        instance._list(plugins)
+        return buf.getvalue()
+
+    def test_plugin_to_dict_full_fields(self):
+        plugin = _make_plugin(
+            "MyTool",
+            category="tools",
+            summary="Parses X reports",
+            tags=["scanner", "web"],
+            author="Alice",
+            version="1.2.3",
+            license="MIT",
+            website="https://example.com",
+        )
+        result = Plugins(json=True)._plugin_to_dict(plugin)
+        assert result == {
+            "name": "MyTool",
+            "summary": "Parses X reports",
+            "tags": ["scanner", "web"],
+            "category": "tools",
+            "author": "Alice",
+            "version": "1.2.3",
+            "license": "MIT",
+            "website": "https://example.com",
+        }
+
+    def test_plugin_to_dict_omits_overwrites_when_none(self):
+        plugin = _make_plugin("Plain", summary="", tags=[])
+        result = Plugins(json=True)._plugin_to_dict(plugin)
+        assert "overwrites" not in result
+
+    def test_plugin_to_dict_includes_overwrites_when_present(self):
+        base = _make_plugin("Base", category="tools")
+        override = _make_plugin("Mine", category="private")
+        override.set_overwrites_plugin(base)
+        result = Plugins(json=True)._plugin_to_dict(override)
+        assert result["overwrites"] == {"name": "Base", "category": "tools"}
+
+    def test_list_outputs_valid_json_array(self):
+        plugins = [
+            _make_plugin("A", summary="alpha", tags=["x"]),
+            _make_plugin("B", summary="beta", tags=[]),
+        ]
+        output = self._run_list(plugins, json_flag=True)
+        parsed = json.loads(output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+        assert [p["name"] for p in parsed] == ["A", "B"]
+        assert parsed[0]["summary"] == "alpha"
+        assert parsed[0]["tags"] == ["x"]
+
+    def test_list_with_no_plugins_returns_empty_json_array(self):
+        output = self._run_list([], json_flag=True)
+        assert json.loads(output) == []
+
+    def test_search_skips_searching_for_banner_when_json(self, monkeypatch):
+        """--json should suppress the colored "Searching for: X" banner."""
+        import reptor.subcommands as subcommands
+
+        groups = {"core": ("Core", [_make_plugin("Apple", tags=["fruit"]), _make_plugin("Avocado", tags=["fruit"])])}
+        monkeypatch.setattr(subcommands, "SUBCOMMANDS_GROUPS", groups)
+
+        instance = Plugins(json=True, search="A")
+        # Replace the console.print with a sentinel that raises if called
+        from reptor.lib.console import reptor_console
+
+        called = {"count": 0}
+
+        def fake_print(*args, **kwargs):
+            called["count"] += 1
+
+        monkeypatch.setattr(reptor_console, "print", fake_print)
+        # _search walks subcommands.SUBCOMMANDS_GROUPS and calls console.print
+        # only when self.search is truthy and self.json is False.
+        instance._search()
+        assert called["count"] == 0
+
+    def test_search_shows_banner_when_not_json(self, monkeypatch):
+        """Without --json, the colored banner is preserved."""
+        import reptor.subcommands as subcommands
+
+        groups = {"core": ("Core", [_make_plugin("Apple", tags=["fruit"]), _make_plugin("Avocado", tags=["fruit"])])}
+        monkeypatch.setattr(subcommands, "SUBCOMMANDS_GROUPS", groups)
+
+        instance = Plugins(json=False, search="A")
+        from reptor.lib.console import reptor_console
+
+        called = {"count": 0}
+
+        def fake_print(*args, **kwargs):
+            called["count"] += 1
+
+        monkeypatch.setattr(reptor_console, "print", fake_print)
+        instance._search()
+        assert called["count"] >= 1  # Banner printed at least once
+
+    def test_add_arguments_registers_json_flag(self, monkeypatch):
+        """--json must be a registered CLI flag on the plugin parser."""
+        import argparse
+
+        parser = argparse.ArgumentParser(prog="reptor")
+        Plugins.add_arguments(parser, plugin_filepath=None)
+        # Parse with --json; expect json=True
+        args = parser.parse_args(["--json"])
+        assert getattr(args, "json", False) is True
+
+        # Without --json; expect json=False
+        args = parser.parse_args([])
+        assert getattr(args, "json", False) is False


### PR DESCRIPTION
## Summary

Mirrors the `--json` convention already established by `reptor note --list`, `reptor project --search`, and `reptor exportfindings`: when `--json` is passed, the plugin list is emitted as a JSON array on stdout instead of a rich table.

```bash
$ reptor plugins --json | jq '.[].name'
"conf"
"finding"
"findingfromtemplate"
"file"
"mcp"
"note"
"plugins"
"project"
"template"
...

$ reptor plugins --json --search owasp | jq '.[0].tags'
["owasp","scanner","web"]
```

## JSON shape

```json
[
  {
    "name": "Plugins",
    "summary": "Allows plugin management & development",
    "tags": [],
    "category": "core",
    "author": "",
    "version": "",
    "license": "",
    "website": ""
  }
]
```

The `overwrites` field is included only when a user-installed plugin shadows a core one:

```json
{
  "name": "MyNmap",
  "...": "...",
  "overwrites": { "name": "Nmap", "category": "tools" }
}
```

## Why

Three siblings already expose a scriptable output format:
- `reptor note --list --json`
- `reptor project --search --json`
- `reptor exportfindings --format json`

`reptor plugins` is the last list-style core command without one. The use cases that motivated it:
- tooling that introspects the plugin list (auto-completion scripts, documentation generators, plugin-availability checks)
- `reptor plugins --json | jq -r '.[].name'` to script plugin discovery
- `reptor plugins --json --search owasp | jq` to filter by tag/name from a shell

## Implementation

3 files, +182 / -1.

- `reptor/plugins/core/Plugins/Plugins.py`:
  - Add `--json` argument (`action="store_true"`, default `False`)
  - Add `_plugin_to_dict(plugin)` helper that mirrors the columns shown in the verbose table
  - In `_list()`, branch on `self.json`: when set, `json.dumps(payload, indent=2)` to stdout and `return`; otherwise existing table path
  - In `_search()`, suppress the colored "Searching for:" banner when `--json` is set so the output stays valid JSON for piping
- `reptor/plugins/core/Plugins/tests/__init__.py`: empty, makes the new tests discoverable
- `reptor/plugins/core/Plugins/tests/test_plugins_json.py`: 8 unit tests

No behavior change for existing callers — `--json` defaults to `False`, so the table output is unchanged.

## Tests

```
$ pytest reptor/plugins/core/Plugins/tests/test_plugins_json.py -v
========================== 8 passed in 0.06s ===========================
```

Covers:
- `_plugin_to_dict` full-fields mapping
- `_plugin_to_dict` omits `overwrites` when no shadow plugin
- `_plugin_to_dict` includes `overwrites` when one exists
- `_list` emits a valid JSON array with correct shape (multi-plugin)
- `_list` emits `[]` for empty input
- `_search` skips the colored banner when `--json` is set
- `_search` keeps the banner when `--json` is not set
- `add_arguments` registers the `--json` flag and parses it correctly

Existing unit suite (excluding GhostWriter which requires the optional `gql` dep) still passes: **218 passed, 76 deselected**.

## Out of scope

- Adding `--json` to other list-style commands (`conf --show`, `template --list`) — separate PRs would follow the same pattern; can be done in a follow-up if you'd like.
- Bumping `reptor.settings.USER_AGENT` from the hard-coded `v0.1.0`. (Pre-existing TODO in the file.)