### PR TITLE
Update & merge fields  on --push-findings instead of skip

### DIFF
--- a/reptor/lib/plugins/ToolBase.py
+++ b/reptor/lib/plugins/ToolBase.py
@@ -456,37 +456,72 @@ class ToolBase(Base):
             )
         self.log.success("Successfully uploaded to notes.")
 
+    def _merge_finding_data(
+        self,
+        new_finding: "Finding",
+        existing_data: dict,
+    ) -> dict:
+        new_data = new_finding.data.to_dict()
+        merged = dict(existing_data)
+        for field_name, new_value in new_data.items():
+            field_obj = getattr(new_finding.data, field_name, None)
+            if (
+                field_obj
+                and hasattr(field_obj, "type")
+                and field_obj.type == "list"
+                and isinstance(new_value, list)
+            ):
+                old_value = existing_data.get(field_name, [])
+                if isinstance(old_value, list):
+                    merged_values = list(set(old_value + new_value))
+                    merged[field_name] = sorted(merged_values, key=str)
+                else:
+                    merged[field_name] = new_value
+            else:
+                merged[field_name] = new_value
+        return merged
+
     def generate_and_push_findings(self) -> None:
         self.generate_findings()
         if len(self.findings) == 0:
             self.log.display("No findings generated.")
             return
-        project_findings = [
-            Finding(f, self._project_design)
-            for f in self.reptor.api.projects.get_findings()
-        ]
-        project_finding_titles = [f.data.title.value for f in project_findings]
+        existing_findings = {
+            f.data.title: f for f in self.reptor.api.projects.get_findings()
+        }
         for finding in self.findings:
-            self.log.info(f'Checking if finding "{finding.data.title.value}" exists')
-            if finding.data.title.value in project_finding_titles:
-                self.log.display(
-                    f'Finding "{finding.data.title.value}" already exists. Skipping.'
+            title = finding.data.title.value
+            existing_raw = existing_findings.get(title)
+            if existing_raw:
+                full_existing = self.reptor.api.projects.get_finding(
+                    existing_raw.id
                 )
-                continue
-
-            self.log.info(f'Pushing finding "{finding.data.title.value}"')
-            if finding.template:
-                # First create from template to keep template reference
-                created_finding = self.reptor.api.projects.create_finding_from_template(
-                    finding.template
+                existing_data = (
+                    full_existing.data.to_dict() if full_existing.data else {}
                 )
-                # ...then update and add data
+                merged_data = self._merge_finding_data(finding, existing_data)
+                if merged_data == existing_data:
+                    self.log.display(f'Skipped finding "{title}" (no changes)')
+                    continue
+                self.log.info(f'Updating finding "{title}"')
                 self.reptor.api.projects.update_finding(
-                    created_finding.id, finding.to_dict()
+                    full_existing.id, {"data": merged_data}
                 )
+                self.log.success(f'Updated finding "{title}"')
             else:
-                self.reptor.api.projects.create_finding(finding.to_dict())
-            self.log.success(f'Pushed finding "{finding.data.title.value}"')
+                self.log.info(f'Pushing finding "{title}"')
+                if finding.template:
+                    created_finding = (
+                        self.reptor.api.projects.create_finding_from_template(
+                            finding.template
+                        )
+                    )
+                    self.reptor.api.projects.update_finding(
+                        created_finding.id, finding.to_dict()
+                    )
+                else:
+                    self.reptor.api.projects.create_finding(finding.to_dict())
+                self.log.success(f'Pushed finding "{title}"')
 
     @cached_property
     def _project_language(self) -> str:

--- a/reptor/plugins/tools/Burp/findings/5243392.toml
+++ b/reptor/plugins/tools/Burp/findings/5243392.toml
@@ -1,5 +1,6 @@
 [data]
 title = "<!--{{ name }}-->"
+affected_components = []
 cvss = "n/a"
 summary = "<!--{{ issueBackground }}-->"
 description = "<!--{{ issueDetail }}-->"

--- a/reptor/plugins/tools/Burp/findings/global.toml
+++ b/reptor/plugins/tools/Burp/findings/global.toml
@@ -1,5 +1,6 @@
 [data]
 title = "<!--{{ name }}-->"
+affected_components = []
 cvss = "n/a"
 summary = "<!--{{ issueBackground }}-->"
 description = "<!--{{ issueDetail }}-->"

--- a/reptor/plugins/tools/Nessus/findings/22964.toml
+++ b/reptor/plugins/tools/Nessus/findings/22964.toml
@@ -1,5 +1,6 @@
 [data]
 title = "Detected network services"
+affected_components = []
 cvss = "n/a"
 severity = "info"
 summary = "<!--{{ synopsis }}-->"

--- a/reptor/plugins/tools/Nessus/findings/global.toml
+++ b/reptor/plugins/tools/Nessus/findings/global.toml
@@ -1,5 +1,6 @@
 [data]
 title = "<!--{{ pluginName }}-->"
+affected_components = []
 cvss = "<!--{{ cvss_vector }}-->"
 summary = "<!--{{ synopsis }}-->"
 recommendation = "<!--{{ solution }}-->"

--- a/reptor/plugins/tools/OpenVAS/findings/1.3.6.1.4.1.25623.1.0.103674.toml
+++ b/reptor/plugins/tools/OpenVAS/findings/1.3.6.1.4.1.25623.1.0.103674.toml
@@ -1,5 +1,6 @@
 [data]
 title = "Unsupported Operating System detected (EOL)"
+affected_components = []
 cvss = "<!--{{ cvss_vector }}-->"
 summary = "<!--{{ summary }}-->"
 description = """

--- a/reptor/plugins/tools/OpenVAS/findings/global.toml
+++ b/reptor/plugins/tools/OpenVAS/findings/global.toml
@@ -1,5 +1,6 @@
 [data]
 title = "<!--{{ name }}-->"
+affected_components = []
 cvss = "<!--{{ cvss_vector }}-->"
 summary = "<!--{{ summary }}-->"
 description = """

--- a/reptor/plugins/tools/Qualys/findings/global.toml
+++ b/reptor/plugins/tools/Qualys/findings/global.toml
@@ -1,5 +1,6 @@
 [data]
 title = "<!--{{ TITLE }}-->"
+affected_components = []
 severity = "<!--{{ severity_label }}-->"
 summary = "<!--{{ DESCRIPTION }}-->"
 description = "<!--{{ IMPACT }}-->"

--- a/reptor/plugins/tools/Sslyze/findings/weak_tls_setup.toml
+++ b/reptor/plugins/tools/Sslyze/findings/weak_tls_setup.toml
@@ -1,5 +1,6 @@
 [data]
 title = "Weak TLS setup might impact encryption"
+affected_components = []
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:N"
 
 summary = """<!--{% load md %}--><!--{% oneliner %}-->

--- a/reptor/plugins/tools/Zap/findings/global.toml
+++ b/reptor/plugins/tools/Zap/findings/global.toml
@@ -1,5 +1,6 @@
 [data]
 title = "<!--{{ name }}-->"
+affected_components = []
 cvss = "<!--{{ cvss }}-->"
 severity = "<!--{{ risk_factor }}-->"
 summary = "<!--{{ description }}-->"


### PR DESCRIPTION
When pushing findings with `--push-findings`, the previous behavior skipped findings that already existed based on their title.

This change updates existing findings in place instead. List-type fields such as `affected_components` are merged rather than overwritten, and a `PATCH` request is only sent when data has actually changed.

This is useful when uploading multiple scans for the same project that contain findings with identical titles but different IPs, hostnames, or assets.

## Changes

- Update existing findings instead of skipping them when a matching title is found.
- Merge list-type fields (e.g. `affected_components`) instead of overwriting them.
- Only send a `PATCH` request when the resulting finding differs from the existing one.
- Add the missing `affected_components = []` field to finding templates so merging works consistently across plugins.

## Example

Consider two scans uploaded to the same project:

- Scan A reports vulnerability **X** on `10.0.0.1`
- Scan B reports vulnerability **X** on `web01.internal`

### Previous behavior

The finding from Scan B is skipped because a finding with the same title already exists.

### New behavior

The existing finding is updated and the `affected_components` values are merged, preserving information from both scans.

## Tools affected by `--push-findings`

| Tool    | Has `finding_*`?            | Builds `affected_components`? | Template patched?                                     |
|----------|----------------------------|-------------------------------|-------------------------------------------------------|
| OpenVAS | ✅ `finding_global`         | ✅                            | ✅ `global.toml`, `1.3.6.1.4.1.25623.1.0.103674.toml` |
| Burp    | ✅ `finding_global`         | ✅                            | ✅ `global.toml`, `5243392.toml`                      |
| Nessus  | ✅ `finding_global`         | ✅                            | ✅ `global.toml`, `22964.toml`                        |
| Qualys  | ✅ `finding_global`         | ✅                            | ✅ `global.toml`                                      |
| Sslyze  | ✅ `finding_weak_tls_setup` | ✅                            | ✅ `weak_tls_setup.toml`                              |
| Zap     | ✅ `finding_global`         | ✅                            | ✅ `global.toml`                                      |
| Nmap    | ❌                          | ❌                            | N/A                                                   |

## Before

![Before](https://github.com/user-attachments/assets/212380fa-aeb2-485a-9137-94cd49f53fe5)

![Before](https://github.com/user-attachments/assets/cab51b1a-3e80-41aa-8559-f2338857f208)

## After

![After](https://github.com/user-attachments/assets/f908b77a-342f-4df9-aea2-c39acef225ae)

![After](https://github.com/user-attachments/assets/f0a6e0b1-57ab-4632-9165-16a45fa1a317)

## Notes

I am not sure whether skipping findings with matching titles was originally intended behavior. However, updating and merging findings appears to be more useful for pentesting workflows where multiple XML scans are imported over time into the same project, allowing affected assets to accumulate under a single finding rather than being silently ignored.