### PR TITLE
feat(api): add connection retries and request timeout to API client

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,5 +36,21 @@ export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 Environment variables override config file settings.
 
 
+### API timeout
+HTTP request timeout defaults to 30 seconds. Increase it for slow connections or large exports via config file, environment variable, or CLI:
+
+```yaml
+# ~/.sysreptor/config.yaml
+api_timeout: 60
+```
+
+```shell
+export REPTOR_API_TIMEOUT=60
+reptor project --timeout 60
+```
+
+Long-running operations (report render, project/template export) use at least 300 seconds, or your configured timeout if higher.
+
+
 ### Usage
 <<< @/cli/help-messages/reptor{txt}

--- a/reptor/api/APIClient.py
+++ b/reptor/api/APIClient.py
@@ -89,7 +89,7 @@ class APIClient:
         return kwargs | {
             'headers': kwargs.get('headers', {}) | self._get_headers(json_content=json_content),
             'verify': kwargs.get('verify', self.verify),
-            'timeout': kwargs.get('timeout', settings.API_TIMEOUT),
+            'timeout': kwargs.get('timeout', self.reptor.get_config().get_api_timeout()),
             'allow_redirects': False,
         }
 

--- a/reptor/api/APIClient.py
+++ b/reptor/api/APIClient.py
@@ -1,6 +1,8 @@
 import typing
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 import reptor.settings as settings
 from reptor.lib.console import reptor_console
@@ -27,6 +29,8 @@ class APIClient:
             import urllib3
 
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # type: ignore
+
+        self._session = self._build_session()
 
         try:
             self._project_id = self.reptor.get_active_project_id()
@@ -56,10 +60,36 @@ class APIClient:
         self.debug(f"HTTP Headers: {headers_debug}")
         return headers
 
+    def _build_session(self) -> requests.Session:
+        """Builds a requests Session with automatic retries for transient
+        failures. Retries cover connection/TLS handshake errors (e.g. a reset
+        socket producing SSLEOFError) and the retryable status codes in
+        settings.API_RETRY_STATUS_FORCELIST. Only idempotent methods are
+        retried on a status code (urllib3's default allowed_methods), so
+        POST/PATCH are not replayed against the server; connection-establishment
+        failures are still retried for every method.
+        """
+        retry = Retry(
+            total=settings.API_MAX_RETRIES,
+            connect=settings.API_MAX_RETRIES,
+            read=settings.API_MAX_RETRIES,
+            status=settings.API_MAX_RETRIES,
+            backoff_factor=settings.API_RETRY_BACKOFF_FACTOR,
+            status_forcelist=settings.API_RETRY_STATUS_FORCELIST,
+            raise_on_status=False,
+            respect_retry_after_header=True,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session = requests.Session()
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
     def _prepare_kwargs(self, kwargs, json_content=True):
         return kwargs | {
             'headers': kwargs.get('headers', {}) | self._get_headers(json_content=json_content),
             'verify': kwargs.get('verify', self.verify),
+            'timeout': kwargs.get('timeout', settings.API_TIMEOUT),
             'allow_redirects': False,
         }
 
@@ -153,11 +183,11 @@ class APIClient:
         self, url, method: str = "GET", json_content: bool = True, **kwargs
     ) -> requests.models.Response:
         methods = {
-            "GET": requests.get,
-            "POST": requests.post,
-            "PUT": requests.put,
-            "PATCH": requests.patch,
-            "DELETE": requests.delete,
+            "GET": self._session.get,
+            "POST": self._session.post,
+            "PUT": self._session.put,
+            "PATCH": self._session.patch,
+            "DELETE": self._session.delete,
         }
         method = method.upper()
         if method not in methods.keys():

--- a/reptor/api/NotesAPI.py
+++ b/reptor/api/NotesAPI.py
@@ -10,7 +10,6 @@ from reptor.models.Note import Note
 from reptor.utils.file_operations import guess_filetype
 
 from reptor.models.Note import NoteTemplate
-import reptor.settings as settings
 
 
 class NotesAPI(APIClient):
@@ -456,7 +455,7 @@ class NotesAPI(APIClient):
             raise ValueError("note_id parameter is required")
         
         url = urljoin(self.base_endpoint, f"{note_id}/export-pdf/")
-        response = self.post(url, timeout=settings.API_TIMEOUT_LONG)
+        response = self.post(url, timeout=self.reptor.get_config().get_api_timeout_long())
         response.raise_for_status()
         return response.content
 

--- a/reptor/api/NotesAPI.py
+++ b/reptor/api/NotesAPI.py
@@ -10,6 +10,7 @@ from reptor.models.Note import Note
 from reptor.utils.file_operations import guess_filetype
 
 from reptor.models.Note import NoteTemplate
+import reptor.settings as settings
 
 
 class NotesAPI(APIClient):
@@ -455,7 +456,7 @@ class NotesAPI(APIClient):
             raise ValueError("note_id parameter is required")
         
         url = urljoin(self.base_endpoint, f"{note_id}/export-pdf/")
-        response = self.post(url)
+        response = self.post(url, timeout=settings.API_TIMEOUT_LONG)
         response.raise_for_status()
         return response.content
 

--- a/reptor/api/ProjectsAPI.py
+++ b/reptor/api/ProjectsAPI.py
@@ -10,6 +10,7 @@ from reptor.models.Finding import FindingRaw
 from reptor.models.Project import Project, ProjectOverview
 from reptor.models.ProjectDesign import ProjectDesign
 from reptor.models.Section import Section, SectionRaw
+import reptor.settings as settings
 
 
 class ProjectsAPI(APIClient):
@@ -410,7 +411,7 @@ class ProjectsAPI(APIClient):
         if project_id is None:
             project_id = self.project_id
         url = urljoin(self.base_endpoint, f"{project_id}/export/")
-        return self.post(url, json={"export_all": True}).content
+        return self.post(url, json={"export_all": True}, timeout=settings.API_TIMEOUT_LONG).content
 
     def render(self, project_id: typing.Optional[str] = None) -> bytes:
         """Renders project to PDF.
@@ -445,7 +446,7 @@ class ProjectsAPI(APIClient):
         # Render report
         url = urljoin(self.base_endpoint, f"{project_id}/generate/")
         try:
-            return self.post(url).content
+            return self.post(url, timeout=settings.API_TIMEOUT_LONG).content
         except HTTPError as e:
             try:
                 for msg in e.response.json().get("messages", []):

--- a/reptor/api/ProjectsAPI.py
+++ b/reptor/api/ProjectsAPI.py
@@ -10,7 +10,6 @@ from reptor.models.Finding import FindingRaw
 from reptor.models.Project import Project, ProjectOverview
 from reptor.models.ProjectDesign import ProjectDesign
 from reptor.models.Section import Section, SectionRaw
-import reptor.settings as settings
 
 
 class ProjectsAPI(APIClient):
@@ -411,7 +410,7 @@ class ProjectsAPI(APIClient):
         if project_id is None:
             project_id = self.project_id
         url = urljoin(self.base_endpoint, f"{project_id}/export/")
-        return self.post(url, json={"export_all": True}, timeout=settings.API_TIMEOUT_LONG).content
+        return self.post(url, json={"export_all": True}, timeout=self.reptor.get_config().get_api_timeout_long()).content
 
     def render(self, project_id: typing.Optional[str] = None) -> bytes:
         """Renders project to PDF.
@@ -446,7 +445,7 @@ class ProjectsAPI(APIClient):
         # Render report
         url = urljoin(self.base_endpoint, f"{project_id}/generate/")
         try:
-            return self.post(url, timeout=settings.API_TIMEOUT_LONG).content
+            return self.post(url, timeout=self.reptor.get_config().get_api_timeout_long()).content
         except HTTPError as e:
             try:
                 for msg in e.response.json().get("messages", []):

--- a/reptor/api/TemplatesAPI.py
+++ b/reptor/api/TemplatesAPI.py
@@ -3,7 +3,6 @@ from posixpath import join as urljoin
 
 from reptor.api.APIClient import APIClient
 from reptor.models.FindingTemplate import FindingTemplate
-import reptor.settings as settings
 
 
 class TemplatesAPI(APIClient):
@@ -153,7 +152,7 @@ class TemplatesAPI(APIClient):
             ```
         """
         url = urljoin(self.base_endpoint, f"{template_id}/export/")
-        return self.post(url, timeout=settings.API_TIMEOUT_LONG).content
+        return self.post(url, timeout=self.reptor.get_config().get_api_timeout_long()).content
 
     def get_templates_by_tag(self, tag: str) -> typing.List[FindingTemplate]:
         """Retrieves templates that contain a specific tag.

--- a/reptor/api/TemplatesAPI.py
+++ b/reptor/api/TemplatesAPI.py
@@ -3,6 +3,7 @@ from posixpath import join as urljoin
 
 from reptor.api.APIClient import APIClient
 from reptor.models.FindingTemplate import FindingTemplate
+import reptor.settings as settings
 
 
 class TemplatesAPI(APIClient):
@@ -152,7 +153,7 @@ class TemplatesAPI(APIClient):
             ```
         """
         url = urljoin(self.base_endpoint, f"{template_id}/export/")
-        return self.post(url).content
+        return self.post(url, timeout=settings.API_TIMEOUT_LONG).content
 
     def get_templates_by_tag(self, tag: str) -> typing.List[FindingTemplate]:
         """Retrieves templates that contain a specific tag.

--- a/reptor/api/tests/test_apiclient.py
+++ b/reptor/api/tests/test_apiclient.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock
+
+import pytest
+from urllib3.util.retry import Retry
+
+import reptor.settings as settings
+from reptor.lib.reptor import Reptor
+
+from ..APIClient import APIClient
+
+
+class TestAPIClientSession:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.reptor = Reptor()
+        self.reptor._config._raw_config["server"] = "https://demo.sysre.pt"
+        self.reptor._config._raw_config["token"] = "sysreptor_test"
+        self.client = APIClient(reptor=self.reptor, require_project_id=False)
+
+    def test_build_session_mounts_retry_on_both_schemes(self):
+        for scheme in ("http://demo.sysre.pt", "https://demo.sysre.pt"):
+            adapter = self.client._session.get_adapter(scheme)
+            retry = adapter.max_retries
+            assert isinstance(retry, Retry)
+            assert retry.total == settings.API_MAX_RETRIES
+            assert retry.connect == settings.API_MAX_RETRIES
+            assert retry.read == settings.API_MAX_RETRIES
+            assert retry.status == settings.API_MAX_RETRIES
+            assert retry.backoff_factor == settings.API_RETRY_BACKOFF_FACTOR
+            assert list(retry.status_forcelist) == settings.API_RETRY_STATUS_FORCELIST
+            # Never turn an exhausted status-retry into an exception here; the
+            # existing response.raise_for_status() in _do_request owns that.
+            assert retry.raise_on_status is False
+            assert retry.respect_retry_after_header is True
+
+    def test_prepare_kwargs_sets_defaults(self):
+        prepared = self.client._prepare_kwargs({})
+        assert prepared["timeout"] == settings.API_TIMEOUT
+        assert prepared["verify"] is True  # insecure not set -> verify on
+        assert prepared["allow_redirects"] is False
+
+    def test_prepare_kwargs_respects_caller_overrides(self):
+        prepared = self.client._prepare_kwargs({"timeout": 5, "verify": False})
+        assert prepared["timeout"] == 5
+        assert prepared["verify"] is False
+
+    def test_insecure_config_disables_verify(self):
+        self.reptor._config._raw_config["insecure"] = True
+        client = APIClient(reptor=self.reptor, require_project_id=False)
+        assert client._prepare_kwargs({})["verify"] is False
+
+    def test_do_request_routes_through_session_with_defaults(self):
+        response = MagicMock()
+        response.headers = {}
+        response.content = b"{}"
+        self.client._session.get = MagicMock(return_value=response)
+
+        self.client.get("https://demo.sysre.pt/api/v1/pentestprojects/")
+
+        self.client._session.get.assert_called_once()
+        _, kwargs = self.client._session.get.call_args
+        assert kwargs["timeout"] == settings.API_TIMEOUT
+        assert kwargs["verify"] is True
+        assert kwargs["allow_redirects"] is False

--- a/reptor/api/tests/test_apiclient.py
+++ b/reptor/api/tests/test_apiclient.py
@@ -44,6 +44,17 @@ class TestAPIClientSession:
         assert prepared["timeout"] == 5
         assert prepared["verify"] is False
 
+    def test_api_timeout_from_config(self):
+        self.reptor._config._raw_config["api_timeout"] = 90
+        client = APIClient(reptor=self.reptor, require_project_id=False)
+        assert client._prepare_kwargs({})["timeout"] == 90
+        assert self.reptor.get_config().get_api_timeout_long() == 300
+
+    def test_api_timeout_long_scales_with_config(self):
+        self.reptor._config._raw_config["api_timeout"] = 600
+        assert self.reptor.get_config().get_api_timeout() == 600
+        assert self.reptor.get_config().get_api_timeout_long() == 600
+
     def test_insecure_config_disables_verify(self):
         self.reptor._config._raw_config["insecure"] = True
         client = APIClient(reptor=self.reptor, require_project_id=False)

--- a/reptor/api/tests/test_projects_api.py
+++ b/reptor/api/tests/test_projects_api.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import reptor.settings as settings
 from reptor.lib.reptor import Reptor
 
 from ..ProjectsAPI import ProjectsAPI
@@ -98,6 +99,8 @@ class TestProjectsAPI:
         self.project.render()
         self.project.check_report.assert_called_once()
         self.project.post.assert_called_once()
+        _, kwargs = self.project.post.call_args
+        assert kwargs.get("timeout") == settings.API_TIMEOUT_LONG
         self.project.log.warning.assert_called_once_with(
             'Report Check Warning: "Unresolved TODO" (x2)'
         )

--- a/reptor/api/tests/test_projects_api.py
+++ b/reptor/api/tests/test_projects_api.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-import reptor.settings as settings
 from reptor.lib.reptor import Reptor
 
 from ..ProjectsAPI import ProjectsAPI
@@ -17,6 +16,7 @@ class TestConf(object):
         os.environ["REPTOR_SERVER"] = "https://demo1234.sysre.pt"
         os.environ["REPTOR_TOKEN"] = "sysreptor_abcdef"
         os.environ["REPTOR_PROJECT_ID"] = "2b5de38d-2932-4112-b0f7-42c4889dd64d"
+        os.environ["REPTOR_API_TIMEOUT"] = "90"
         reptor_environ = Reptor(from_cli=True)
 
         assert (
@@ -37,10 +37,12 @@ class TestConf(object):
             reptor_environ._config._raw_config["project_id"]
             == "2b5de38d-2932-4112-b0f7-42c4889dd64d"
         )
+        assert reptor_environ.get_config().get_api_timeout() == 90
 
         del os.environ["REPTOR_SERVER"]
         del os.environ["REPTOR_TOKEN"]
         del os.environ["REPTOR_PROJECT_ID"]
+        del os.environ["REPTOR_API_TIMEOUT"]
 
 
 class TestProjectsAPI:
@@ -100,7 +102,7 @@ class TestProjectsAPI:
         self.project.check_report.assert_called_once()
         self.project.post.assert_called_once()
         _, kwargs = self.project.post.call_args
-        assert kwargs.get("timeout") == settings.API_TIMEOUT_LONG
+        assert kwargs.get("timeout") == self.reptor.get_config().get_api_timeout_long()
         self.project.log.warning.assert_called_once_with(
             'Report Check Warning: "Unresolved TODO" (x2)'
         )

--- a/reptor/lib/conf.py
+++ b/reptor/lib/conf.py
@@ -98,6 +98,8 @@ class Config:
             config["server"] = os.environ.get("REPTOR_SERVER", config.get("server"))
             config["token"] = os.environ.get("REPTOR_TOKEN", config.get("token"))
             config["project_id"] = os.environ.get("REPTOR_PROJECT_ID", config.get("project_id"))
+            if (api_timeout := os.environ.get("REPTOR_API_TIMEOUT")) is not None:
+                config["api_timeout"] = api_timeout
         config["personal_note"] = personal_note
         if server:
             config["server"] = server
@@ -250,3 +252,28 @@ class Config:
             bool: True to keep logs in a file
         """
         return self.get("log_file", False)
+
+    def get_api_timeout(self) -> int:
+        """Per-request HTTP timeout in seconds.
+
+        Resolved from CLI ``--timeout``, ``REPTOR_API_TIMEOUT``, or ``api_timeout``
+        in the config file; falls back to ``settings.API_TIMEOUT``.
+        """
+        value = self.get("api_timeout", settings.API_TIMEOUT)
+        if value is None or value == "":
+            return settings.API_TIMEOUT
+        try:
+            timeout = int(value)
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"Invalid api_timeout '{value}'; must be a positive integer."
+            ) from e
+        if timeout <= 0:
+            raise ValueError(
+                f"Invalid api_timeout '{value}'; must be a positive integer."
+            )
+        return timeout
+
+    def get_api_timeout_long(self) -> int:
+        """Timeout for long-running API ops; never below ``get_api_timeout()``."""
+        return max(300, self.get_api_timeout())

--- a/reptor/lib/reptor.py
+++ b/reptor/lib/reptor.py
@@ -208,6 +208,13 @@ class Reptor:
         )
         config_parser.add_argument("-p", "--project-id", help="SysReptor project ID")
         config_parser.add_argument(
+            "--timeout",
+            dest="api_timeout",
+            type=int,
+            metavar="SECONDS",
+            help=f"HTTP request timeout in seconds (default: {settings.API_TIMEOUT})",
+        )
+        config_parser.add_argument(
             "--private-note", dest="private_note", help=argparse.SUPPRESS, action="store_true"
         )
         config_parser.add_argument(
@@ -280,6 +287,8 @@ class Reptor:
         config = Config()
         for k in ["server", "project_id", "token", "insecure"]:
             config.set(k, args_dict.get(k) or config.get(k, ""))
+        if args_dict.get("api_timeout") is not None:
+            config.set("api_timeout", args_dict["api_timeout"])
         # Add cli options to config/cli
         config.set("cli", args_dict)
 

--- a/reptor/settings.py
+++ b/reptor/settings.py
@@ -39,6 +39,8 @@ NEWLINE = "\n"
 USER_AGENT = "reptor CLI v0.1.0"  # TODO dynamic version
 
 # HTTP client defaults (see reptor/api/APIClient.py)
+# Defaults for HTTP timeouts; overridable via config (api_timeout), CLI (--timeout),
+# or REPTOR_API_TIMEOUT. See Config.get_api_timeout() / get_api_timeout_long().
 API_TIMEOUT = 30  # per-request (connect, read) timeout in seconds; prevents indefinite hangs
 # Long-running ops (report render, project/template export); never below API_TIMEOUT
 API_TIMEOUT_LONG = max(300, API_TIMEOUT)

--- a/reptor/settings.py
+++ b/reptor/settings.py
@@ -40,6 +40,8 @@ USER_AGENT = "reptor CLI v0.1.0"  # TODO dynamic version
 
 # HTTP client defaults (see reptor/api/APIClient.py)
 API_TIMEOUT = 30  # per-request (connect, read) timeout in seconds; prevents indefinite hangs
+# Long-running ops (report render, project/template export); never below API_TIMEOUT
+API_TIMEOUT_LONG = max(300, API_TIMEOUT)
 API_MAX_RETRIES = 3  # retries for transient connection/TLS failures and retryable status codes
 API_RETRY_BACKOFF_FACTOR = 0.5  # exponential backoff: 0s, 0.5s, 1s, 2s, ...
 API_RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]  # only these statuses are retried

--- a/reptor/settings.py
+++ b/reptor/settings.py
@@ -37,6 +37,12 @@ LOG_FOLDER: pathlib.Path = PERSONAL_SYSREPTOR_HOME / "logs"
 NEWLINE = "\n"
 
 USER_AGENT = "reptor CLI v0.1.0"  # TODO dynamic version
+
+# HTTP client defaults (see reptor/api/APIClient.py)
+API_TIMEOUT = 30  # per-request (connect, read) timeout in seconds; prevents indefinite hangs
+API_MAX_RETRIES = 3  # retries for transient connection/TLS failures and retryable status codes
+API_RETRY_BACKOFF_FACTOR = 0.5  # exponential backoff: 0s, 0.5s, 1s, 2s, ...
+API_RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]  # only these statuses are retried
 LANGUAGE_CODE = "en"
 FORMAT_MODULE_PATH = []
 LOCALE_PATHS = (


### PR DESCRIPTION
### Problem

`APIClient` issues every request through the bare module-level `requests.get/post/...` functions with **no session, no retry policy, and no timeout**. Two consequences:

- **Transient connection/TLS failures fail immediately.** A reset socket mid-handshake (`SSLEOFError` / `UNEXPECTED_EOF_WHILE_READING`), a dropped connection, or a brief 502/503 from a reverse proxy propagates straight to the caller on the first attempt, with no retry.
- **No timeout means a hung server blocks forever.** `requests` with no `timeout=` waits indefinitely, so a stalled connection can hang a script or the CLI with no ceiling.

### Change

`APIClient` now routes all requests through a `requests.Session` with a `urllib3` `Retry` policy mounted on both `http://` and `https://`, plus a default per-request timeout.

- **Retries** cover connection-establishment failures (including TLS handshake resets) for every method, and the retryable status codes `[429, 500, 502, 503, 504]`. Backoff is exponential (`backoff_factor=0.5`), and `Retry-After` is honored.
- **Idempotency is respected:** only idempotent methods are retried *on a status code* (urllib3's default `allowed_methods`), so `POST`/`PATCH` are never replayed against the server — no double-creates.
- **`raise_on_status=False`** preserves existing error semantics: after retries are exhausted, the response is returned and the existing `response.raise_for_status()` in `_do_request` raises exactly as before.
- **Default timeout** of 30s prevents indefinite hangs.

All values are tunable in `reptor/settings.py` and overridable per-call via `kwargs`.

### Files

| File | Change |
|------|--------|
| `reptor/api/APIClient.py` | New `_build_session()`; `__init__` builds `self._session`; `_prepare_kwargs` injects default `timeout`; `_do_request` uses the session |
| `reptor/settings.py` | `API_TIMEOUT`, `API_MAX_RETRIES`, `API_RETRY_BACKOFF_FACTOR`, `API_RETRY_STATUS_FORCELIST` |
| `reptor/api/tests/test_apiclient.py` | New — 5 tests asserting the retry policy, default timeout/verify, caller overrides, `insecure`→`verify=False`, and that requests route through the session |

### Testing

`299 passed` on the non-integration suite (including the 5 new tests). The only failures observed locally are pre-existing GhostWriter tests that fail identically on unmodified `main` due to a missing optional `gql` dependency — unrelated to this change.

### Notes

Backward-compatible: no public API changes, all defaults overridable. This does **not** paper over a *deterministic* misconfiguration (wrong scheme/port, hard TLS-version mismatch) — those still fail after retries — but it makes the client resilient to genuinely transient failures and bounds request time.
