### PR TITLE
fix(project): gracefully handle missing project ID instead of raising ValueError

### DIFF
--- a/reptor/plugins/projects/Project/Project.py
+++ b/reptor/plugins/projects/Project/Project.py
@@ -206,6 +206,14 @@ class Project(Base):
         )
 
     def run(self):
+        # Commands that need a project ID
+        if self.export or self.render or self.duplicate or self.finish is not None:
+            if not self.reptor.get_active_project_id():
+                self.error(
+                    "No project ID configured. Use --project-id or run 'reptor conf' to set one."
+                )
+                return
+
         if self.export:
             self._export_project(self.export, filename=self.output, upload=self.upload)
         elif self.render:


### PR DESCRIPTION
## Description

Fixes #108 — the Project plugin now gracefully handles missing project IDs instead of crashing with a raw ValueError traceback.

### Problem
Running `reptor project --export` (or `--render`, `--duplicate`, `--finish`) without a configured project ID raises an unhandled `ValueError`:
```
ValueError: No Project ID configured. Try 'reptor conf' or use '--project-id'.
```

### Fix
Added an early check in `Project.run()` for commands that require a project ID. If no project ID is set, it prints a friendly error message and returns cleanly instead of raising an exception.

### Changes
- `reptor/plugins/projects/Project/Project.py`: Added project ID check before `--export`, `--render`, `--duplicate`, and `--finish` operations

### Testing
- All 9 existing unit tests pass
- No project ID → friendly error message instead of traceback
- With project ID → behavior unchanged
