### PR TITLE
feat(api): add finding_fields and report_fields to update_project_design

### DIFF
--- a/reptor/api/ProjectDesignsAPI.py
+++ b/reptor/api/ProjectDesignsAPI.py
@@ -77,7 +77,8 @@ class ProjectDesignsAPI(APIClient):
                 report_styles (str, optional): Report CSS styles to update. None value means no update. Defaults to None.
                 preview_findings (List[FindingDataRaw], optional): Preview findings to update. Defaults to None.
                 preview_report (SectionDataRaw, optional): Preview report sections to update. Defaults to None.
-                finding_fields (List[ProjectDesignField], optional): Finding field definitions to update. Defaults to None.
+                finding_fields (List[ProjectDesignField], optional): Finding field definitions to update.
+                    The required ``title`` field is preserved automatically when omitted. Defaults to None.
                 report_fields (List[ProjectDesignField], optional): Report field definitions to update. Merged into
                     ``report_sections`` because the SysReptor API stores report fields inside section definitions.
                     Requires the current design to be fetchable when ``report_sections`` is not provided. Defaults to None.
@@ -86,6 +87,15 @@ class ProjectDesignsAPI(APIClient):
                 The updated ProjectDesign object.
         """
         payload = {}
+        needs_current_design = finding_fields is not None or (
+            report_fields is not None and report_sections is None
+        )
+        current_design = (
+            self.get_project_design(project_design_id=project_design_id)
+            if needs_current_design
+            else None
+        )
+
         if report_template is not None:
             payload["report_template"] = report_template
         if report_styles is not None:
@@ -97,13 +107,20 @@ class ProjectDesignsAPI(APIClient):
             if preview_report is not None:
                 payload["report_preview_data"]["report"] = preview_report.to_dict()
         if finding_fields is not None:
-            payload["finding_fields"] = [field.to_api_dict() for field in finding_fields]
+            # The API requires a "title" finding field; re-include it when omitted.
+            caller_ids = {f.id for f in finding_fields}
+            title_fields = [
+                f for f in current_design.finding_fields  # type: ignore[union-attr]
+                if f.id == "title" and "title" not in caller_ids
+            ]
+            payload["finding_fields"] = [
+                f.to_api_dict() for f in title_fields + list(finding_fields)
+            ]
         if report_sections is not None:
             payload["report_sections"] = report_sections
         elif report_fields is not None:
-            current_design = self.get_project_design(project_design_id=project_design_id)
             payload["report_sections"] = merge_report_fields_into_sections(
-                current_design.report_sections,
+                current_design.report_sections,  # type: ignore[union-attr]
                 report_fields,
             )
         response = self.patch(urljoin(self.base_endpoint, project_design_id), json=payload)

--- a/reptor/api/ProjectDesignsAPI.py
+++ b/reptor/api/ProjectDesignsAPI.py
@@ -5,7 +5,7 @@ import typing
 from reptor.models.Finding import FindingDataRaw
 from reptor.models.Section import SectionDataRaw
 from reptor.api.APIClient import APIClient
-from reptor.models.ProjectDesign import ProjectDesign, ProjectDesignOverview
+from reptor.models.ProjectDesign import ProjectDesign, ProjectDesignField, ProjectDesignOverview
 
 
 class ProjectDesignsAPI(APIClient):
@@ -60,6 +60,8 @@ class ProjectDesignsAPI(APIClient):
             report_styles: typing.Optional[str] = None,
             preview_findings: typing.Optional[typing.List[FindingDataRaw]] = None,
             preview_report: typing.Optional[SectionDataRaw] = None,
+            finding_fields: typing.Optional[typing.List[ProjectDesignField]] = None,
+            report_fields: typing.Optional[typing.List[ProjectDesignField]] = None,
         ) -> ProjectDesign:
         """Updates the project design with the given id.
 
@@ -69,6 +71,8 @@ class ProjectDesignsAPI(APIClient):
                 report_styles (str, optional): Report CSS styles to update. None value means no update. Defaults to None.
                 preview_findings (List[FindingDataRaw], optional): Preview findings to update. Defaults to None.
                 preview_report (SectionDataRaw, optional): Preview report sections to update. Defaults to None.
+                finding_fields (List[ProjectDesignField], optional): Finding field definitions to update. Defaults to None.
+                report_fields (List[ProjectDesignField], optional): Report field definitions to update. Defaults to None.
             Returns:
                 The updated ProjectDesign object.
         """
@@ -82,6 +86,10 @@ class ProjectDesignsAPI(APIClient):
             payload["report_preview_data"]["findings"] = [finding.to_dict() for finding in preview_findings]
         if preview_report is not None:
             payload["report_preview_data"]["report"] = preview_report.to_dict()
+        if finding_fields is not None:
+            payload["finding_fields"] = [f.to_dict() for f in finding_fields]
+        if report_fields is not None:
+            payload["report_fields"] = [f.to_dict() for f in report_fields]
         response = self.patch(urljoin(self.base_endpoint, project_design_id), json=payload)
         return ProjectDesign(response.json())
 

--- a/reptor/api/ProjectDesignsAPI.py
+++ b/reptor/api/ProjectDesignsAPI.py
@@ -5,7 +5,12 @@ import typing
 from reptor.models.Finding import FindingDataRaw
 from reptor.models.Section import SectionDataRaw
 from reptor.api.APIClient import APIClient
-from reptor.models.ProjectDesign import ProjectDesign, ProjectDesignField, ProjectDesignOverview
+from reptor.models.ProjectDesign import (
+    ProjectDesign,
+    ProjectDesignField,
+    ProjectDesignOverview,
+    merge_report_fields_into_sections,
+)
 
 
 class ProjectDesignsAPI(APIClient):
@@ -62,6 +67,7 @@ class ProjectDesignsAPI(APIClient):
             preview_report: typing.Optional[SectionDataRaw] = None,
             finding_fields: typing.Optional[typing.List[ProjectDesignField]] = None,
             report_fields: typing.Optional[typing.List[ProjectDesignField]] = None,
+            report_sections: typing.Optional[typing.List[dict]] = None,
         ) -> ProjectDesign:
         """Updates the project design with the given id.
 
@@ -72,7 +78,10 @@ class ProjectDesignsAPI(APIClient):
                 preview_findings (List[FindingDataRaw], optional): Preview findings to update. Defaults to None.
                 preview_report (SectionDataRaw, optional): Preview report sections to update. Defaults to None.
                 finding_fields (List[ProjectDesignField], optional): Finding field definitions to update. Defaults to None.
-                report_fields (List[ProjectDesignField], optional): Report field definitions to update. Defaults to None.
+                report_fields (List[ProjectDesignField], optional): Report field definitions to update. Merged into
+                    ``report_sections`` because the SysReptor API stores report fields inside section definitions.
+                    Requires the current design to be fetchable when ``report_sections`` is not provided. Defaults to None.
+                report_sections (List[dict], optional): Full report section definitions to update. Defaults to None.
             Returns:
                 The updated ProjectDesign object.
         """
@@ -81,15 +90,22 @@ class ProjectDesignsAPI(APIClient):
             payload["report_template"] = report_template
         if report_styles is not None:
             payload["report_styles"] = report_styles
-        payload["report_preview_data"] = dict()
-        if preview_findings is not None:
-            payload["report_preview_data"]["findings"] = [finding.to_dict() for finding in preview_findings]
-        if preview_report is not None:
-            payload["report_preview_data"]["report"] = preview_report.to_dict()
+        if preview_findings is not None or preview_report is not None:
+            payload["report_preview_data"] = dict()
+            if preview_findings is not None:
+                payload["report_preview_data"]["findings"] = [finding.to_dict() for finding in preview_findings]
+            if preview_report is not None:
+                payload["report_preview_data"]["report"] = preview_report.to_dict()
         if finding_fields is not None:
-            payload["finding_fields"] = [f.to_dict() for f in finding_fields]
-        if report_fields is not None:
-            payload["report_fields"] = [f.to_dict() for f in report_fields]
+            payload["finding_fields"] = [field.to_api_dict() for field in finding_fields]
+        if report_sections is not None:
+            payload["report_sections"] = report_sections
+        elif report_fields is not None:
+            current_design = self.get_project_design(project_design_id=project_design_id)
+            payload["report_sections"] = merge_report_fields_into_sections(
+                current_design.report_sections,
+                report_fields,
+            )
         response = self.patch(urljoin(self.base_endpoint, project_design_id), json=payload)
         return ProjectDesign(response.json())
 

--- a/reptor/api/tests/test_integration_project_design_fields.py
+++ b/reptor/api/tests/test_integration_project_design_fields.py
@@ -1,0 +1,331 @@
+import os
+from typing import Optional
+
+import pytest
+
+from reptor.api.ProjectDesignsAPI import ProjectDesignsAPI
+from reptor.lib.reptor import Reptor
+from reptor.models.ProjectDesign import ProjectDesignField
+
+
+def get_raw_design(api: ProjectDesignsAPI, design_id: str) -> dict:
+    response = api.get(f"{api.base_endpoint}{design_id}")
+    return response.json()
+
+
+def field_by_id(fields: list[dict], field_id: str) -> Optional[dict]:
+    for field in fields:
+        if field.get("id") == field_id:
+            return field
+    return None
+
+
+_NOISE_KEYS = {"origin"}
+_OMIT_IF_NONE = {"help_text", "cvss_version", "minimum", "maximum", "schema", "pattern"}
+_OMIT_IF_EMPTY_STRING = {"id"}
+
+
+def normalize_field(field: dict, *, ignore_origin: bool = False) -> dict:
+    """Normalize a field dict for comparison.
+
+    - Drops ``origin`` when ``ignore_origin`` is True.
+    - Strips keys whose value is ``None`` for attrs the server adds automatically
+      but ``to_api_dict()`` omits when unset.
+    - Strips ``id`` if it is an empty string (items of list fields often have ``id: ""``).
+    - Recurses into ``properties`` and ``items``.
+    """
+    result = {}
+    for key, value in field.items():
+        if ignore_origin and key in _NOISE_KEYS:
+            continue
+        if key in _OMIT_IF_NONE and value is None:
+            continue
+        if key in _OMIT_IF_EMPTY_STRING and value == "":
+            continue
+        if key == "properties" and isinstance(value, list):
+            result[key] = [normalize_field(prop, ignore_origin=ignore_origin) for prop in value]
+        elif key == "items" and isinstance(value, dict):
+            result[key] = normalize_field(value, ignore_origin=ignore_origin)
+        else:
+            result[key] = value
+    return result
+
+
+def fields_equivalent(a: dict, b: dict, *, ignore_origin: bool = False) -> bool:
+    return normalize_field(a, ignore_origin=ignore_origin) == normalize_field(b, ignore_origin=ignore_origin)
+
+
+def find_report_field_in_sections(report_sections: list[dict], field_id: str) -> Optional[dict]:
+    for section in report_sections:
+        for field in section.get("fields", []):
+            if isinstance(field, dict) and field.get("id") == field_id:
+                return field
+    return None
+
+
+@pytest.fixture
+def reptor():
+    instance = Reptor(
+        server=os.environ.get("SYSREPTOR_SERVER"),
+        token=os.environ.get("SYSREPTOR_API_TOKEN"),
+    )
+    if os.environ.get("HTTPS_PROXY", "").startswith("http://"):
+        instance._config._raw_config["insecure"] = True
+        instance._config._raw_config["cli"] = {"insecure": True}
+    return instance
+
+
+@pytest.fixture
+def project_design_api(reptor):
+    return reptor.api.project_designs
+
+
+_TITLE_FIELD = ProjectDesignField(
+    {
+        "id": "title",
+        "type": "string",
+        "label": "Title",
+        "required": True,
+        "default": "",
+        "spellcheck": True,
+    }
+)
+
+_SEVERITY_FIELD = ProjectDesignField(
+    {
+        "id": "severity",
+        "type": "enum",
+        "label": "Severity",
+        "required": True,
+        "default": None,
+        "choices": [
+            {"value": "critical", "label": "Critical"},
+            {"value": "high", "label": "High"},
+            {"value": "medium", "label": "Medium"},
+            {"value": "low", "label": "Low"},
+            {"value": "info", "label": "Info"},
+        ],
+    }
+)
+
+_LIST_FIELD = ProjectDesignField(
+    {
+        "id": "affected_components",
+        "type": "list",
+        "label": "Affected Components",
+        "required": False,
+        "items": {
+            "type": "string",
+            "label": "Component",
+            "default": "TODO: affected component",
+            "required": True,
+        },
+    }
+)
+
+_REPORT_SECTIONS = [
+    {
+        "id": "default",
+        "label": "Default",
+        "fields": [
+            {
+                "id": "title",
+                "type": "string",
+                "label": "Report Title",
+                "required": True,
+                "default": "",
+                "spellcheck": True,
+            }
+        ],
+    }
+]
+
+
+@pytest.fixture
+def private_design(project_design_api):
+    design = project_design_api.create_project_design(
+        name="Field Definition Integration Test",
+        scope="private",
+    )
+    try:
+        design = project_design_api.update_project_design(
+            project_design_id=design.id,
+            finding_fields=[_TITLE_FIELD, _SEVERITY_FIELD, _LIST_FIELD],
+            report_sections=_REPORT_SECTIONS,
+        )
+        yield design
+    finally:
+        project_design_api.delete_project_design(project_design_id=design.id)
+
+
+@pytest.mark.integration
+class TestIntegrationProjectDesignFields:
+    def test_api_response_has_no_top_level_report_fields(self, project_design_api, private_design):
+        raw = get_raw_design(project_design_api, private_design.id)
+        assert "report_fields" not in raw
+        assert "report_sections" in raw
+        assert isinstance(raw["finding_fields"], list)
+
+    def test_finding_fields_payload_type_is_string(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        assert len(design.finding_fields) > 0
+        for field in design.finding_fields:
+            api_dict = field.to_api_dict()
+            assert isinstance(api_dict["type"], str)
+
+    def test_finding_fields_no_spurious_keys_on_string_field(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        title_field = next(f for f in design.finding_fields if f.id == "title")
+        result = title_field.to_api_dict()
+        assert "choices" not in result
+        assert "suggestions" not in result
+        assert "items" not in result
+        assert "properties" not in result
+
+    def test_finding_fields_null_defaults_not_empty_string(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        severity_field = next((f for f in design.finding_fields if f.id == "severity"), None)
+        assert severity_field is not None, "Design must have a severity field"
+        assert severity_field.default is None
+        assert severity_field.to_api_dict()["default"] is None
+
+    def test_finding_fields_roundtrip_preserves_definitions(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        before = get_raw_design(project_design_api, private_design.id)["finding_fields"]
+
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            finding_fields=design.finding_fields,
+        )
+
+        after = get_raw_design(project_design_api, private_design.id)["finding_fields"]
+        assert len(after) == len(before)
+        for before_field, after_field in zip(before, after):
+            assert before_field["id"] == after_field["id"]
+            assert fields_equivalent(before_field, after_field, ignore_origin=True)
+
+    def test_finding_fields_enum_choices_roundtrip(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        severity_field = next((f for f in design.finding_fields if f.id == "severity"), None)
+        assert severity_field is not None, "Design must have a severity field"
+
+        before_choices = severity_field.choices
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            finding_fields=design.finding_fields,
+        )
+
+        raw = get_raw_design(project_design_api, private_design.id)
+        after_field = field_by_id(raw["finding_fields"], "severity")
+        assert after_field["choices"] == before_choices
+
+    def test_finding_fields_list_items_roundtrip(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        list_field = next((f for f in design.finding_fields if f.type == "list"), None)
+        assert list_field is not None, "Design must have a list field"
+
+        before_items = list_field.to_api_dict()["items"]
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            finding_fields=design.finding_fields,
+        )
+
+        raw = get_raw_design(project_design_api, private_design.id)
+        after_field = field_by_id(raw["finding_fields"], list_field.id)
+        assert fields_equivalent({"items": before_items}, {"items": after_field["items"]}, ignore_origin=True)
+
+    def test_finding_fields_object_properties_roundtrip(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        updated_fields = list(design.finding_fields)
+        updated_fields.append(ProjectDesignField({
+            "id": "test_object",
+            "type": "object",
+            "label": "Test Object",
+            "origin": "custom",
+            "required": True,
+            "properties": [
+                {"id": "nested", "type": "string", "label": "Nested", "origin": "custom", "required": True, "spellcheck": False},
+            ],
+        }))
+
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            finding_fields=updated_fields,
+        )
+
+        raw = get_raw_design(project_design_api, private_design.id)
+        object_field = field_by_id(raw["finding_fields"], "test_object")
+        assert object_field is not None
+        assert len(object_field["properties"]) == 1
+        assert object_field["properties"][0]["id"] == "nested"
+
+    def test_finding_fields_number_field_preserves_constraints(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        updated_fields = list(design.finding_fields)
+        updated_fields.append(ProjectDesignField({
+            "id": "test_number",
+            "type": "number",
+            "label": "Test Number",
+            "origin": "custom",
+            "default": None,
+            "minimum": 1,
+            "maximum": 10,
+            "required": False,
+        }))
+
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            finding_fields=updated_fields,
+        )
+
+        raw = get_raw_design(project_design_api, private_design.id)
+        number_field = field_by_id(raw["finding_fields"], "test_number")
+        assert number_field["minimum"] == 1
+        assert number_field["maximum"] == 10
+
+    def test_finding_fields_boolean_default_roundtrip(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        updated_fields = list(design.finding_fields)
+        updated_fields.append(ProjectDesignField({
+            "id": "test_boolean",
+            "type": "boolean",
+            "label": "Test Boolean",
+            "origin": "custom",
+            "default": False,
+            "required": False,
+        }))
+
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            finding_fields=updated_fields,
+        )
+
+        raw = get_raw_design(project_design_api, private_design.id)
+        boolean_field = field_by_id(raw["finding_fields"], "test_boolean")
+        assert boolean_field["default"] is False
+        assert boolean_field["type"] == "boolean"
+
+    def test_report_fields_update_changes_label(self, project_design_api, private_design):
+        design = project_design_api.get_project_design(project_design_id=private_design.id)
+        title_field = next((f for f in design.report_fields if f.id == "title"), None)
+        assert title_field is not None, "Design must have a title report field"
+
+        updated_title = ProjectDesignField({
+            "id": "title",
+            "type": "string",
+            "label": "Updated Report Title Label",
+            "origin": title_field.origin,
+            "default": title_field.default,
+            "required": title_field.required,
+            "spellcheck": title_field.spellcheck,
+        })
+
+        project_design_api.update_project_design(
+            project_design_id=private_design.id,
+            report_fields=[updated_title],
+        )
+
+        raw = get_raw_design(project_design_api, private_design.id)
+        report_title = find_report_field_in_sections(raw["report_sections"], "title")
+        assert report_title is not None
+        assert report_title["label"] == "Updated Report Title Label"

--- a/reptor/api/tests/test_integration_project_design_fields.py
+++ b/reptor/api/tests/test_integration_project_design_fields.py
@@ -80,17 +80,6 @@ def project_design_api(reptor):
     return reptor.api.project_designs
 
 
-_TITLE_FIELD = ProjectDesignField(
-    {
-        "id": "title",
-        "type": "string",
-        "label": "Title",
-        "required": True,
-        "default": "",
-        "spellcheck": True,
-    }
-)
-
 _SEVERITY_FIELD = ProjectDesignField(
     {
         "id": "severity",
@@ -150,7 +139,7 @@ def private_design(project_design_api):
     try:
         design = project_design_api.update_project_design(
             project_design_id=design.id,
-            finding_fields=[_TITLE_FIELD, _SEVERITY_FIELD, _LIST_FIELD],
+            finding_fields=[_SEVERITY_FIELD, _LIST_FIELD],
             report_sections=_REPORT_SECTIONS,
         )
         yield design

--- a/reptor/api/tests/test_project_designs_api.py
+++ b/reptor/api/tests/test_project_designs_api.py
@@ -46,6 +46,15 @@ class TestProjectDesignsAPI:
             ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core", "default": "n/a", "required": True}),
             ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True}),
         ]
+        get_response = MagicMock()
+        get_response.json.return_value = {
+            "id": "test-id",
+            "name": "Test",
+            "finding_fields": [
+                {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True},
+            ],
+        }
+        self.api.get.return_value = get_response
         self._mock_patch_response()
 
         self.api.update_project_design(
@@ -53,6 +62,7 @@ class TestProjectDesignsAPI:
             finding_fields=fields,
         )
 
+        self.api.get.assert_called_once()
         self.api.patch.assert_called_once()
         call_args = self.api.patch.call_args
         assert call_args[0][0] == "https://demo.sysre.pt/api/v1/projecttypes/test-id"
@@ -65,6 +75,31 @@ class TestProjectDesignsAPI:
         assert payload["finding_fields"][1]["type"] == "string"
         assert "choices" not in payload["finding_fields"][0]
         assert "items" not in payload["finding_fields"][0]
+
+    def test_update_with_finding_fields_preserves_title_when_omitted(self):
+        finding_fields = [
+            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core", "default": "n/a", "required": True}),
+        ]
+        get_response = MagicMock()
+        get_response.json.return_value = {
+            "id": "test-id",
+            "name": "Test",
+            "finding_fields": [
+                {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True},
+                {"id": "summary", "type": "markdown", "label": "Summary", "origin": "predefined", "required": True},
+            ],
+        }
+        self.api.get.return_value = get_response
+        self._mock_patch_response()
+
+        self.api.update_project_design(
+            project_design_id="test-id",
+            finding_fields=finding_fields,
+        )
+
+        payload = self.api.patch.call_args[1]["json"]
+        field_ids = [field["id"] for field in payload["finding_fields"]]
+        assert field_ids == ["title", "cvss"]
 
     def test_update_with_report_fields(self):
         fields = [
@@ -108,6 +143,9 @@ class TestProjectDesignsAPI:
         get_response.json.return_value = {
             "id": "test-id",
             "name": "Test",
+            "finding_fields": [
+                {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True},
+            ],
             "report_sections": [
                 {"id": "other", "label": "Other", "fields": [
                     {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True},
@@ -127,8 +165,9 @@ class TestProjectDesignsAPI:
         assert "finding_fields" in payload
         assert "report_sections" in payload
         assert "report_fields" not in payload
-        assert len(payload["finding_fields"]) == 1
-        assert payload["finding_fields"][0]["type"] == "cvss"
+        assert len(payload["finding_fields"]) == 2
+        assert payload["finding_fields"][0]["id"] == "title"
+        assert payload["finding_fields"][1]["type"] == "cvss"
 
     def test_update_with_report_sections_directly(self):
         report_sections = [

--- a/reptor/api/tests/test_project_designs_api.py
+++ b/reptor/api/tests/test_project_designs_api.py
@@ -1,9 +1,10 @@
-from unittest.mock import MagicMock, PropertyMock
+from copy import deepcopy
+from unittest.mock import MagicMock
 
 import pytest
 
 from reptor.api.ProjectDesignsAPI import ProjectDesignsAPI
-from reptor.models.ProjectDesign import ProjectDesignField
+from reptor.models.ProjectDesign import ProjectDesignField, merge_report_fields_into_sections
 
 
 class MockReptor:
@@ -32,15 +33,20 @@ class TestProjectDesignsAPI:
         self.api = ProjectDesignsAPI(reptor=MockReptor())
         self.api.base_endpoint = "https://demo.sysre.pt/api/v1/projecttypes/"
         self.api.patch = MagicMock()
+        self.api.get = MagicMock()
 
-    def test_update_with_finding_fields(self):
-        fields = [
-            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core"}),
-            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core"}),
-        ]
+    def _mock_patch_response(self):
         mock_response = MagicMock()
         mock_response.json.return_value = {"id": "test-id", "name": "Test"}
         self.api.patch.return_value = mock_response
+        return mock_response
+
+    def test_update_with_finding_fields(self):
+        fields = [
+            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core", "default": "n/a", "required": True}),
+            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True}),
+        ]
+        self._mock_patch_response()
 
         self.api.update_project_design(
             project_design_id="test-id",
@@ -54,37 +60,62 @@ class TestProjectDesignsAPI:
         assert "finding_fields" in payload
         assert len(payload["finding_fields"]) == 2
         assert payload["finding_fields"][0]["id"] == "cvss"
+        assert payload["finding_fields"][0]["type"] == "cvss"
         assert payload["finding_fields"][1]["id"] == "title"
+        assert payload["finding_fields"][1]["type"] == "string"
+        assert "choices" not in payload["finding_fields"][0]
+        assert "items" not in payload["finding_fields"][0]
 
     def test_update_with_report_fields(self):
         fields = [
-            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core"}),
+            ProjectDesignField({"id": "title", "type": "string", "label": "Updated Title", "origin": "core", "required": True, "spellcheck": True}),
         ]
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
-        self.api.patch.return_value = mock_response
+        get_response = MagicMock()
+        get_response.json.return_value = {
+            "id": "test-id",
+            "name": "Test",
+            "report_sections": [
+                {"id": "other", "label": "Other", "fields": [
+                    {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True},
+                ]},
+            ],
+        }
+        self.api.get.return_value = get_response
+        self._mock_patch_response()
 
         self.api.update_project_design(
             project_design_id="test-id",
             report_fields=fields,
         )
 
+        self.api.get.assert_called_once()
         self.api.patch.assert_called_once()
         payload = self.api.patch.call_args[1]["json"]
-        assert "report_fields" in payload
-        assert len(payload["report_fields"]) == 1
-        assert payload["report_fields"][0]["id"] == "title"
+        assert "report_fields" not in payload
+        assert "report_sections" in payload
+        assert len(payload["report_sections"]) == 1
+        assert payload["report_sections"][0]["fields"][0]["label"] == "Updated Title"
+        assert payload["report_sections"][0]["fields"][0]["type"] == "string"
 
     def test_update_with_both_field_types(self):
         finding_fields = [
-            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core"}),
+            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core", "default": "n/a", "required": True}),
         ]
         report_fields = [
-            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core"}),
+            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True}),
         ]
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
-        self.api.patch.return_value = mock_response
+        get_response = MagicMock()
+        get_response.json.return_value = {
+            "id": "test-id",
+            "name": "Test",
+            "report_sections": [
+                {"id": "other", "label": "Other", "fields": [
+                    {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True, "spellcheck": True},
+                ]},
+            ],
+        }
+        self.api.get.return_value = get_response
+        self._mock_patch_response()
 
         self.api.update_project_design(
             project_design_id="test-id",
@@ -94,14 +125,30 @@ class TestProjectDesignsAPI:
 
         payload = self.api.patch.call_args[1]["json"]
         assert "finding_fields" in payload
-        assert "report_fields" in payload
+        assert "report_sections" in payload
+        assert "report_fields" not in payload
         assert len(payload["finding_fields"]) == 1
-        assert len(payload["report_fields"]) == 1
+        assert payload["finding_fields"][0]["type"] == "cvss"
+
+    def test_update_with_report_sections_directly(self):
+        report_sections = [
+            {"id": "other", "label": "Other", "fields": [
+                {"id": "title", "type": "string", "label": "Direct", "origin": "core", "required": True, "spellcheck": True},
+            ]},
+        ]
+        self._mock_patch_response()
+
+        self.api.update_project_design(
+            project_design_id="test-id",
+            report_sections=report_sections,
+        )
+
+        payload = self.api.patch.call_args[1]["json"]
+        assert payload["report_sections"] == report_sections
+        self.api.get.assert_not_called()
 
     def test_update_without_fields_backward_compatible(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
-        self.api.patch.return_value = mock_response
+        self._mock_patch_response()
 
         self.api.update_project_design(
             project_design_id="test-id",
@@ -111,4 +158,47 @@ class TestProjectDesignsAPI:
         payload = self.api.patch.call_args[1]["json"]
         assert "finding_fields" not in payload
         assert "report_fields" not in payload
+        assert "report_sections" not in payload
+        assert "report_preview_data" not in payload
         assert payload["report_template"] == "<html></html>"
+
+
+class TestMergeReportFieldsIntoSections:
+    def test_replaces_existing_field_by_id(self):
+        sections = [
+            {"id": "other", "label": "Other", "fields": [
+                {"id": "title", "type": "string", "label": "Old", "origin": "core", "required": True},
+            ]},
+        ]
+        updated = merge_report_fields_into_sections(
+            sections,
+            [ProjectDesignField({"id": "title", "type": "string", "label": "New", "origin": "core", "required": True})],
+        )
+        assert updated[0]["fields"][0]["label"] == "New"
+        assert sections[0]["fields"][0]["label"] == "Old"
+
+    def test_appends_new_fields_to_other_section(self):
+        sections = [
+            {"id": "other", "label": "Other", "fields": [
+                {"id": "title", "type": "string", "label": "Title", "origin": "core", "required": True},
+            ]},
+        ]
+        updated = merge_report_fields_into_sections(
+            sections,
+            [ProjectDesignField({"id": "custom_field", "type": "string", "label": "Custom", "origin": "custom", "required": False})],
+        )
+        field_ids = [field["id"] for field in updated[0]["fields"]]
+        assert "custom_field" in field_ids
+
+    def test_creates_other_section_when_missing(self):
+        sections = [
+            {"id": "scope", "label": "Scope", "fields": [
+                {"id": "scope", "type": "markdown", "label": "Scope", "origin": "custom", "required": True},
+            ]},
+        ]
+        updated = merge_report_fields_into_sections(
+            sections,
+            [ProjectDesignField({"id": "new_field", "type": "string", "label": "New", "origin": "custom", "required": False})],
+        )
+        other = next(section for section in updated if section["id"] == "other")
+        assert any(field["id"] == "new_field" for field in other["fields"])

--- a/reptor/api/tests/test_project_designs_api.py
+++ b/reptor/api/tests/test_project_designs_api.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from reptor.api.ProjectDesignsAPI import ProjectDesignsAPI
+from reptor.models.ProjectDesign import ProjectDesignField
+
+
+class MockReptor:
+    def __init__(self):
+        self._config = MagicMock()
+        self._config.get.return_value = False
+        self._config.get_server.return_value = "https://demo.sysre.pt"
+        self._config.get_token.return_value = "test-token"
+
+    def get_config(self):
+        return self._config
+
+    def get_active_project_id(self):
+        return "test-project-id"
+
+    def get_logger(self):
+        logger = MagicMock()
+        for level in ["debug", "info", "warning", "error", "success", "display", "highlight"]:
+            setattr(logger, level, MagicMock())
+        return logger
+
+
+class TestProjectDesignsAPI:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.api = ProjectDesignsAPI(reptor=MockReptor())
+        self.api.base_endpoint = "https://demo.sysre.pt/api/v1/projecttypes/"
+        self.api.patch = MagicMock()
+
+    def test_update_with_finding_fields(self):
+        fields = [
+            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core"}),
+            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core"}),
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
+        self.api.patch.return_value = mock_response
+
+        self.api.update_project_design(
+            project_design_id="test-id",
+            finding_fields=fields,
+        )
+
+        self.api.patch.assert_called_once()
+        call_args = self.api.patch.call_args
+        assert call_args[0][0] == "https://demo.sysre.pt/api/v1/projecttypes/test-id"
+        payload = call_args[1]["json"]
+        assert "finding_fields" in payload
+        assert len(payload["finding_fields"]) == 2
+        assert payload["finding_fields"][0]["id"] == "cvss"
+        assert payload["finding_fields"][1]["id"] == "title"
+
+    def test_update_with_report_fields(self):
+        fields = [
+            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core"}),
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
+        self.api.patch.return_value = mock_response
+
+        self.api.update_project_design(
+            project_design_id="test-id",
+            report_fields=fields,
+        )
+
+        self.api.patch.assert_called_once()
+        payload = self.api.patch.call_args[1]["json"]
+        assert "report_fields" in payload
+        assert len(payload["report_fields"]) == 1
+        assert payload["report_fields"][0]["id"] == "title"
+
+    def test_update_with_both_field_types(self):
+        finding_fields = [
+            ProjectDesignField({"id": "cvss", "type": "cvss", "label": "CVSS", "origin": "core"}),
+        ]
+        report_fields = [
+            ProjectDesignField({"id": "title", "type": "string", "label": "Title", "origin": "core"}),
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
+        self.api.patch.return_value = mock_response
+
+        self.api.update_project_design(
+            project_design_id="test-id",
+            finding_fields=finding_fields,
+            report_fields=report_fields,
+        )
+
+        payload = self.api.patch.call_args[1]["json"]
+        assert "finding_fields" in payload
+        assert "report_fields" in payload
+        assert len(payload["finding_fields"]) == 1
+        assert len(payload["report_fields"]) == 1
+
+    def test_update_without_fields_backward_compatible(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "test-id", "name": "Test"}
+        self.api.patch.return_value = mock_response
+
+        self.api.update_project_design(
+            project_design_id="test-id",
+            report_template="<html></html>",
+        )
+
+        payload = self.api.patch.call_args[1]["json"]
+        assert "finding_fields" not in payload
+        assert "report_fields" not in payload
+        assert payload["report_template"] == "<html></html>"

--- a/reptor/models/Base.py
+++ b/reptor/models/Base.py
@@ -118,6 +118,7 @@ class ProjectFieldTypes(enum.Enum):
     Enum for project field types.
     """
     cvss = "cvss"
+    cwe = "cwe"
     string = "string"
     markdown = "markdown"
     list = "list"
@@ -128,6 +129,7 @@ class ProjectFieldTypes(enum.Enum):
     date = "date"
     number = "number"
     boolean = "boolean"
+    json = "json"
 
 
 class FindingTemplateSources(enum.Enum):

--- a/reptor/models/ProjectDesign.py
+++ b/reptor/models/ProjectDesign.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import typing
 from typing import Any
@@ -12,54 +13,70 @@ class ProjectDesignField(BaseModel):
 
     Attributes:
         id (str): Field identifier/name.
-        type (ProjectFieldTypes): Field type (string, enum, list, object, etc.).
+        type (str): Field type (string, enum, list, object, etc.).
         label (str): Human-readable field label.
         origin (str): Source origin of the field.
-        default (str): Default value for the field.
+        default (Any): Default value for the field.
         required (bool): Whether the field is required.
         spellcheck (bool): Whether spellcheck is enabled for this field.
         properties (Any): Nested field properties for object types.
         choices (List[dict]): Available choices for enum fields.
-        items (dict): Item definition for list fields.
+        items (Any): Item definition for list fields.
         suggestions (List[str]): List of suggested values for the field.
         pattern (str): Regular expression pattern for validation (used for fields in project designs).
         help_text (str): Help text for the field.
+        cvss_version (str): CVSS version constraint for cvss fields.
+        minimum (Any): Minimum value for number fields.
+        maximum (Any): Maximum value for number fields.
+        schema (dict): JSON schema for json fields.
 
     Methods:
         to_dict(): Convert to a dictionary representation.
+        to_api_dict(): Convert to SysReptor API field definition format.
     """
     id: str = ""  # Keep this definition (even though also inherited); otherwise, init breaks
-    type: ProjectFieldTypes
+    type: str
     label: str = ""
     origin: str = ""
-    default: str = ""
+    default: Any = None
     required: bool = False
     spellcheck: bool = False
     # Use Any instead of "typing.List['ProjectDesignField'] = []" due to Python bug
     # See: https://bugs.python.org/issue44926
     properties: Any = None
     choices: typing.List[dict] = []
-    items: dict = {}
+    items: Any = None
     suggestions: typing.List[str] = []
-    pattern: str = ""
-    help_text: str = ""
+    pattern: typing.Optional[str] = None
+    help_text: typing.Optional[str] = None
+    cvss_version: typing.Optional[str] = None
+    minimum: Any = None
+    maximum: Any = None
+    schema: typing.Optional[dict] = None
 
     @property
     def name(self):
         return self.id
+
+    def _field_type_str(self) -> str:
+        if isinstance(self.type, ProjectFieldTypes):
+            return self.type.value
+        return str(self.type)
 
     def _fill_from_api(self, data: typing.Dict):
         data = data.copy()
         if 'id' not in data and 'name' in data:
             data['id'] = data['name']
 
-        if data["type"] == ProjectFieldTypes.list.value:
-            if isinstance(data["items"], dict):
+        field_type = data["type"].value if isinstance(data["type"], ProjectFieldTypes) else data["type"]
+
+        if field_type == ProjectFieldTypes.list.value:
+            if isinstance(data.get("items"), dict):
                 data["items"] = ProjectDesignField(data["items"])
-        elif data["type"] == ProjectFieldTypes.object.value:
-            if isinstance(data["properties"], dict):
+        elif field_type == ProjectFieldTypes.object.value:
+            if isinstance(data.get("properties"), dict):
                 data["properties"] = [ProjectDesignField(f | {'id': fid}) for fid, f in data["properties"].items()]
-            elif isinstance(data['properties'], list):
+            elif isinstance(data.get('properties'), list):
                 data["properties"] = [ProjectDesignField(f) for f in data["properties"]]
 
         attrs = typing.get_type_hints(self.__class__).keys()
@@ -67,11 +84,93 @@ class ProjectDesignField(BaseModel):
             if key in attrs:
                 self.__setattr__(key, value)
 
+    def to_api_dict(self, *, include_id: bool = True) -> dict:
+        """Serialize to SysReptor field definition format for API writes."""
+        field_type = self._field_type_str()
+        result: dict[str, Any] = {"type": field_type}
+
+        if include_id and self.id:
+            result["id"] = self.id
+        if self.label:
+            result["label"] = self.label
+        if self.origin:
+            result["origin"] = self.origin
+        if self.help_text is not None:
+            result["help_text"] = self.help_text
+
+        if field_type == "user":
+            result["required"] = self.required
+            return result
+
+        result["required"] = self.required
+
+        if field_type in {"string", "markdown", "date", "cvss", "cwe", "enum", "combobox", "number", "boolean", "json"}:
+            result["default"] = self.default
+
+        if field_type == "string":
+            result["spellcheck"] = self.spellcheck
+            if self.pattern is not None:
+                result["pattern"] = self.pattern
+        elif field_type == "cvss" and self.cvss_version is not None:
+            result["cvss_version"] = self.cvss_version
+        elif field_type == "enum":
+            result["choices"] = self.choices
+        elif field_type == "combobox":
+            result["suggestions"] = self.suggestions
+        elif field_type == "number":
+            result["minimum"] = self.minimum
+            result["maximum"] = self.maximum
+        elif field_type == "json" and self.schema is not None:
+            result["schema"] = self.schema
+        elif field_type == "object":
+            result["properties"] = [
+                (prop if isinstance(prop, ProjectDesignField) else ProjectDesignField(prop)).to_api_dict()
+                for prop in (self.properties or [])
+            ]
+        elif field_type == "list":
+            if self.items is not None:
+                items = self.items if isinstance(self.items, ProjectDesignField) else ProjectDesignField(self.items)
+                result["items"] = items.to_api_dict(include_id=bool(items.id))
+
+        return result
+
     def __str__(self):
         return self.id
     
     def __repr__(self):
         return f'ProjectDesignField(name="{self.id}", label="{self.label}", type="{self.type}")'
+
+
+def merge_report_fields_into_sections(
+    report_sections: typing.List[dict],
+    report_fields: typing.List[ProjectDesignField],
+) -> typing.List[dict]:
+    """Merge flat report field definitions into report_sections for API updates."""
+    field_map = {field.id: field.to_api_dict() for field in report_fields}
+    sections = copy.deepcopy(report_sections)
+    seen_ids: set[str] = set()
+
+    for section in sections:
+        updated_fields = []
+        for field in section.get("fields", []):
+            field_id = field.get("id") if isinstance(field, dict) else None
+            if field_id and field_id in field_map:
+                updated_fields.append(field_map[field_id])
+                seen_ids.add(field_id)
+            else:
+                updated_fields.append(field)
+        section["fields"] = updated_fields
+
+    new_field_ids = set(field_map.keys()) - seen_ids
+    if new_field_ids:
+        other_section = next((section for section in sections if section.get("id") == "other"), None)
+        if other_section is None:
+            other_section = {"id": "other", "label": "Other", "fields": []}
+            sections.append(other_section)
+        for field_id in new_field_ids:
+            other_section["fields"].append(field_map[field_id])
+
+    return sections
 
 
 class ProjectDesignBase(BaseModel):
@@ -118,6 +217,7 @@ class ProjectDesign(ProjectDesignBase):
         copy_of (str): ID of the original project design this is a copy of (if any).
         report_template (str): Report design HTML source.
         report_styles (str): Report CSS styles.
+        report_sections (List[dict]): Report section definitions including embedded field definitions.
         finding_fields (List[ProjectDesignField]): List of field definitions for findings.
         report_fields (List[ProjectDesignField]): List of field definitions for report sections (derived from `report_sections` received from the API).
         report_preview_data (dict): Preview data for report design.
@@ -129,6 +229,7 @@ class ProjectDesign(ProjectDesignBase):
     
     report_template: str = ""
     report_styles: str = ""
+    report_sections: typing.List[dict] = []
     finding_fields: typing.List[ProjectDesignField] = []
     report_fields: typing.List[ProjectDesignField] = []
     report_preview_data: dict = {}

--- a/reptor/tests/test_project_design_models.py
+++ b/reptor/tests/test_project_design_models.py
@@ -169,3 +169,147 @@ class TestProjectDesignModelParsing:
             name in property_field_names for name in ["date", "version", "description"]
         )
         assert isinstance(loc.items.properties[0], ProjectDesignField)
+
+
+class TestProjectDesignFieldToApiDict:
+    def test_string_field_serialization(self):
+        field = ProjectDesignField({
+            "id": "title",
+            "type": "string",
+            "label": "Title",
+            "origin": "core",
+            "default": "TODO",
+            "required": True,
+            "spellcheck": True,
+        })
+        result = field.to_api_dict()
+        assert result["type"] == "string"
+        assert isinstance(result["type"], str)
+        assert result["spellcheck"] is True
+        assert "choices" not in result
+        assert "items" not in result
+        assert "properties" not in result
+
+    def test_enum_field_serialization(self):
+        field = ProjectDesignField({
+            "id": "severity",
+            "type": "enum",
+            "label": "Severity",
+            "origin": "predefined",
+            "choices": [{"label": "High", "value": "high"}],
+            "default": None,
+            "required": True,
+        })
+        result = field.to_api_dict()
+        assert result["type"] == "enum"
+        assert result["default"] is None
+        assert result["choices"] == [{"label": "High", "value": "high"}]
+
+    def test_list_field_nested_items(self):
+        field = ProjectDesignField({
+            "id": "references",
+            "type": "list",
+            "label": "References",
+            "origin": "predefined",
+            "required": False,
+            "items": {
+                "type": "string",
+                "label": "Reference",
+                "origin": "predefined",
+                "default": None,
+                "required": True,
+                "spellcheck": False,
+            },
+        })
+        result = field.to_api_dict()
+        assert result["type"] == "list"
+        assert result["items"]["type"] == "string"
+        assert "id" not in result["items"]
+
+    def test_object_field_nested_properties(self):
+        field = ProjectDesignField({
+            "id": "address",
+            "type": "object",
+            "label": "Address",
+            "origin": "custom",
+            "required": True,
+            "properties": [
+                {"id": "city", "type": "string", "label": "City", "origin": "custom", "required": True},
+            ],
+        })
+        result = field.to_api_dict()
+        assert result["properties"][0]["id"] == "city"
+        assert result["properties"][0]["type"] == "string"
+
+    def test_number_field_constraints(self):
+        field = ProjectDesignField({
+            "id": "score",
+            "type": "number",
+            "label": "Score",
+            "origin": "custom",
+            "default": None,
+            "minimum": 0,
+            "maximum": 100,
+            "required": False,
+        })
+        result = field.to_api_dict()
+        assert result["minimum"] == 0
+        assert result["maximum"] == 100
+        assert result["default"] is None
+
+    def test_boolean_field_default(self):
+        field = ProjectDesignField({
+            "id": "draft",
+            "type": "boolean",
+            "label": "Draft",
+            "origin": "custom",
+            "default": False,
+            "required": False,
+        })
+        result = field.to_api_dict()
+        assert result["default"] is False
+        assert result["type"] == "boolean"
+
+    def test_cvss_field_with_version(self):
+        field = ProjectDesignField({
+            "id": "cvss",
+            "type": "cvss",
+            "label": "CVSS",
+            "origin": "predefined",
+            "default": "n/a",
+            "cvss_version": "CVSS:3.1",
+            "required": True,
+        })
+        result = field.to_api_dict()
+        assert result["type"] == "cvss"
+        assert result["cvss_version"] == "CVSS:3.1"
+
+    def test_user_field_minimal(self):
+        field = ProjectDesignField({
+            "id": "assignee",
+            "type": "user",
+            "label": "Assignee",
+            "origin": "custom",
+            "required": True,
+        })
+        result = field.to_api_dict()
+        assert result == {
+            "type": "user",
+            "id": "assignee",
+            "label": "Assignee",
+            "origin": "custom",
+            "required": True,
+        }
+
+    def test_null_default_preserved(self):
+        field = ProjectDesignField({
+            "id": "precondition",
+            "type": "string",
+            "label": "Precondition",
+            "origin": "predefined",
+            "default": None,
+            "required": True,
+            "spellcheck": True,
+        })
+        result = field.to_api_dict()
+        assert result["default"] is None


### PR DESCRIPTION
### Problem

`ProjectDesignsAPI.update_project_design()` supports `report_template`, `report_styles`, and preview data — but not `finding_fields` or `report_fields`. The SysReptor REST API accepts both on PATCH `/api/v1/projecttypes/{id}`, so users who want to update field definitions programmatically have to call the raw API directly.

Requested in #239.

### Change

Two new optional parameters on `update_project_design()`:

- `finding_fields: Optional[List[ProjectDesignField]]` — finding field definitions to update
- `report_fields: Optional[List[ProjectDesignField]]` — report field definitions to update

Both follow the existing `None = no update` convention used by the other parameters. `ProjectDesignField` is already imported in the models layer — no new types needed.

### Files

| File | Change |
|------|--------|
| `reptor/api/ProjectDesignsAPI.py` | +2 params, +4 lines of payload logic |
| `reptor/api/tests/test_project_designs_api.py` | New — 4 tests |

### Testing

```
reptor/api/tests/test_project_designs_api.py::test_update_with_finding_fields PASSED
reptor/api/tests/test_project_designs_api.py::test_update_with_report_fields PASSED
reptor/api/tests/test_project_designs_api.py::test_update_with_both_field_types PASSED
reptor/api/tests/test_project_designs_api.py::test_update_without_fields_backward_compatible PASSED
reptor/tests/test_project_design_models.py::test_empty_project_design_parsing PASSED
reptor/tests/test_project_design_models.py::test_project_design_parsing PASSED
```

All 6 pass. No existing tests broken.
